### PR TITLE
Adds back profile images (sourced from Robohash)

### DIFF
--- a/backend/controllers/lobbyControllers.js
+++ b/backend/controllers/lobbyControllers.js
@@ -23,17 +23,17 @@ const getLobby = async (req, res) => {
   const { id: gameId } = req.params;
   const { id: userId } = req.session.user;
 
-  const getLobbyQuery = `SELECT g.id, g.name, g.active
+  const getLobbyQuery = `SELECT id, name, active
     FROM games g
-    LEFT JOIN game_users gu ON g.id = gu.game_id
-    WHERE (g.id = $1)
-    AND g.id IN (
-      SELECT game_id
-      FROM game_users
-      WHERE users_id = $2
+    WHERE (id = $1)
+    AND EXISTS (
+        SELECT game_id
+        FROM game_users
+        WHERE users_id = $2
+        AND game_id = $1
     )`;
 
-  const playerListQuery = `SELECT u.username FROM users u 
+  const playerListQuery = `SELECT u.username, u.image FROM users u 
     LEFT JOIN game_users gu ON u.id = gu.users_id 
     WHERE (gu.game_id = $1)`;
 

--- a/backend/routes/chat.js
+++ b/backend/routes/chat.js
@@ -1,13 +1,10 @@
 const express = require("express");
 const router = express.Router();
-const { createHash } = require("crypto");
 
 const handler = (req, res) => {
   const { id: roomId } = req.params;
   const { message } = req.body;
-  const { email } = req.session.user;
-
-  console.log({ email });
+  const { image, username } = req.session.user;
 
   const io = req.app.get("io");
 
@@ -15,8 +12,8 @@ const handler = (req, res) => {
   console.log(roomId);
   //Step 2 Chat: Emit Socket IO Event with message
   io.emit(`chat:message:${roomId === undefined ? 0 : roomId}`, {
-    hash: createHash("sha256").update(email).digest("hex"),
-    from: req.session.user.username,
+    image: image,
+    from: username,
     timestamp: Date.now(),
     message,
   });

--- a/backend/views/lobby.ejs
+++ b/backend/views/lobby.ejs
@@ -48,13 +48,13 @@
     <div id = "player-container">
         <% players.forEach(player => { %>
             <p class="player-name">
-                <%= player.name %>
+                <%= player.username %>
             </p>
             <img
               class="player-card"
               
-              src=""
-              alt= <%= player.name %>
+              src= <%= player.image %>
+              alt= <%= player.username %>
             />
             <% }); %>
     </div>

--- a/migrations/1701584530972_add-user-images-back.js
+++ b/migrations/1701584530972_add-user-images-back.js
@@ -6,7 +6,7 @@ exports.up = (pgm) => {
   pgm.addColumn("users", {
     image: {
       type: "varchar(85)",
-      notNull: false,
+      notNull: true,
       default: "https://robohash.org/a1b2c3",
     },
   });

--- a/migrations/1701584530972_add-user-images-back.js
+++ b/migrations/1701584530972_add-user-images-back.js
@@ -1,0 +1,17 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.addColumn("users", {
+    image: {
+      type: "varchar(85)",
+      notNull: false,
+      default: "https://robohash.org/a1b2c3",
+    },
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropColumn("users", "image");
+};


### PR DESCRIPTION
### Summary

Adds column profile_image to table USERS.

When users register, their email is used to generate a hash which acts as the link to their static, unique profile image served from Robohash. This link is stored in that column.

When users login, the link is added to the session context object as 'image'.

### Checklist

- [x] Tested the code and it does not break anything
- [ ] `npm run format:fix`
- [x] Commits / PR title are easy for others to follow :smiley:
