### PR TITLE
Cookie secured and Proxy trusted for Render in Production

### DIFF
--- a/backend/db/session.js
+++ b/backend/db/session.js
@@ -15,6 +15,7 @@ const sessionConfig = expressSession({
   resave: false,
   saveUninitialized: true,
   cookie: {
+    secure: process.env.NODE_ENV === "production",
     maxAge: parseInt(process.env.COOKIE_MAX_AGE) || 10 * 24 * 60 * 60 * 1000,
   },
 });

--- a/backend/server.js
+++ b/backend/server.js
@@ -24,7 +24,11 @@ app.use(express.static("frontend"));
 const { sessionConfig, setLocalUserData } = require("./db/session");
 const { displayErrors } = require("./middleware/display-errors");
 
-if (process.env.NODE_ENV == "development") {
+if (process.env.NODE_ENV === "production") {
+  app.set("trust proxy", true);
+}
+
+if (process.env.NODE_ENV === "development") {
   const livereload = require("livereload");
   const connectLiveReload = require("connect-livereload");
 


### PR DESCRIPTION
### Summary

If the Node environment is set to 'production', the cookies in Express Session are made secure (HTTPS).
Due to Render supposedly using a reverse-proxy, the Express app has to trust it for cookie security to work properly, which is also only done in 'production'.

Already tested on Render and should be working.

### Checklist

- [x] Tested the code and it does not break anything
- [x] `npm run format:fix`
- [x] Commits / PR title are easy for others to follow :smiley:
