### PR TITLE
65 implement the uno button

### DIFF
--- a/backend/routes/game.js
+++ b/backend/routes/game.js
@@ -8,6 +8,7 @@ const {
   createGame,
   getMyGames,
   startGame,
+  unoAccuse,
 } = require("../controllers/gameControllers");
 
 gameRouter.post("/:id/card/play", playCard);
@@ -23,5 +24,7 @@ gameRouter.get("/:id", getGame);
 gameRouter.post("/:id/card/draw", drawCard);
 
 gameRouter.post("/startGame", startGame);
+
+gameRouter.post("/:id/unoAccuse", unoAccuse);
 
 module.exports = gameRouter;

--- a/backend/views/game.ejs
+++ b/backend/views/game.ejs
@@ -58,6 +58,9 @@
       </div>
       <%- include('partials/chat', { chatMessages: messages, roomId: gameId } ) %>
     </main>
+    <div id="declare-uno-container" class="hidden">
+     Declare Uno: <input type="checkbox" name="declare-uno-button" id="declare-uno-button" />
+    </div>
     <div class="client-hand">
       <% clientHand.forEach(card => { %>
       <img

--- a/migrations/1702019293455_add-declared-uno-column.js
+++ b/migrations/1702019293455_add-declared-uno-column.js
@@ -1,0 +1,17 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.addColumns("game_users", {
+    declared_uno: {
+      type: "boolean",
+      notNull: true,
+      default: false,
+    },
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropColumns("game_users", ["declared_uno"]);
+};


### PR DESCRIPTION
### Summary

This PR implements the uno button
This PR displays a checkbox for when a player has 2 cards in hand. 
If the player clicks this button and then successfully plays a card, they have declared uno and this status is saved in the db 
in the game_users table in a new column called declared_uno
This PR creates the migration that creates the declared_uno boolean column in the game_users table.
This PR makes it so that if a player clicks the uno button and one or more players have not declared uno and they have one card in hand, those players draw 2 cards each.

### Checklist

- [ ] Tested the code and it does not break anything
- [x] `npm run format:fix`
- [x] Commits / PR title are easy for others to follow :smiley:
- [ ] Include a screenshot if it's for a view :sunglasses:
